### PR TITLE
Grafana 13.0.1

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,3 +13,4 @@
   `ERROR: pull access denied, repository does not exist or may require authorization:
   server message: insufficient_scope: authorization failed`
 - Grafana: Updated to v13.0.1
+- Grafana: Updated plugin manifest list

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,3 +12,4 @@
 - Grafana: Fixed OCI building on GHA
   `ERROR: pull access denied, repository does not exist or may require authorization:
   server message: insufficient_scope: authorization failed`
+- Grafana: Updated to v13.0.1

--- a/suraya/grafana/Dockerfile
+++ b/suraya/grafana/Dockerfile
@@ -9,7 +9,7 @@
 # export BUILDKIT_PROGRESS=plain
 
 # Define Grafana and Python versions.
-ARG GRAFANA_VERSION="11.4.0"
+ARG GRAFANA_VERSION="13.0.1"
 ARG PYTHON_VERSION="3.14"
 
 FROM docker.io/python:${PYTHON_VERSION}-slim-bookworm AS plugins
@@ -79,7 +79,7 @@ RUN \
 
 
 # Derive from Grafana OSS.
-FROM grafana/grafana-oss:${GRAFANA_VERSION}-ubuntu
+FROM docker.io/grafana/grafana:${GRAFANA_VERSION}-ubuntu
 
 # Switch from user `grafana` to `root`,
 # in order to permit reconfiguring the image.

--- a/suraya/grafana/Dockerfile
+++ b/suraya/grafana/Dockerfile
@@ -10,9 +10,9 @@
 
 # Define Grafana and Python versions.
 ARG GRAFANA_VERSION="11.4.0"
-ARG PYTHON_VERSION="3.13"
+ARG PYTHON_VERSION="3.14"
 
-FROM python:${PYTHON_VERSION}-slim-bookworm AS plugins
+FROM docker.io/python:${PYTHON_VERSION}-slim-bookworm AS plugins
 
 # Configure operating system, and `pip` and `uv` package managers.
 ENV DEBIAN_FRONTEND=noninteractive

--- a/suraya/grafana/plugin-manifest.json
+++ b/suraya/grafana/plugin-manifest.json
@@ -7,119 +7,119 @@
     },
     {
       "slug": "alexanderzobnin-zabbix-app",
-      "version": "4.6.1"
+      "version": "6.3.0"
     },
     {
       "slug": "dlopes7-appdynamics-datasource",
-      "version": "3.10.4"
+      "version": "3.12.2"
     },
     {
       "slug": "grafana-athena-datasource",
-      "version": "3.0.0"
+      "version": "3.2.0"
     },
     {
       "slug": "grafana-bigquery-datasource",
-      "version": "2.0.1"
+      "version": "3.1.5"
     },
     {
       "slug": "grafana-clickhouse-datasource",
-      "version": "4.5.1"
+      "version": "4.15.0"
     },
     {
       "slug": "grafana-clock-panel",
-      "version": "2.1.8"
+      "version": "3.2.2"
     },
     {
       "slug": "grafana-cloudflare-datasource",
-      "version": "0.1.2-preview"
+      "version": "0.2.1-preview"
     },
     {
       "slug": "grafana-datadog-datasource",
-      "version": "3.12.4"
+      "version": "3.17.1"
     },
     {
       "slug": "grafana-dynatrace-datasource",
-      "version": "3.21.4"
+      "version": "3.26.3"
     },
     {
       "slug": "grafana-github-datasource",
-      "version": "2.0.1"
+      "version": "2.8.0"
     },
     {
       "slug": "grafana-gitlab-datasource",
-      "version": "2.3.11"
+      "version": "2.4.1"
     },
     {
       "slug": "grafana-googlesheets-datasource",
-      "version": "2.0.1"
+      "version": "2.5.0"
     },
     {
       "slug": "grafana-honeycomb-datasource",
-      "version": "2.7.7"
+      "version": "2.15.0"
     },
     {
       "slug": "grafana-iot-sitewise-datasource",
-      "version": "1.25.2"
+      "version": "2.6.0"
     },
     {
       "slug": "grafana-iot-twinmaker-app",
-      "version": "2.0.0"
+      "version": "2.1.5"
     },
     {
       "slug": "grafana-jira-datasource",
-      "version": "1.11.4"
+      "version": "2.6.1"
     },
     {
       "slug": "grafana-mongodb-datasource",
-      "version": "1.22.8"
+      "version": "1.26.5"
     },
     {
       "slug": "grafana-newrelic-datasource",
-      "version": "4.6.8"
+      "version": "4.6.17"
     },
     {
       "slug": "grafana-opensearch-datasource",
-      "version": "2.22.3"
+      "version": "2.33.1"
     },
     {
       "slug": "grafana-oracle-datasource",
-      "version": "2.10.4"
+      "version": "3.4.1"
     },
     {
       "slug": "grafana-redshift-datasource",
-      "version": "1.20.0"
+      "version": "2.5.0"
     },
     {
       "slug": "grafana-salesforce-datasource",
-      "version": "1.7.8"
+      "version": "1.7.19"
     },
     {
       "slug": "grafana-saphana-datasource",
-      "version": "1.7.5"
+      "version": "1.7.17"
     },
     {
       "slug": "grafana-servicenow-datasource",
-      "version": "2.12.14"
+      "version": "2.14.3"
     },
     {
       "slug": "grafana-splunk-datasource",
-      "version": "5.4.1"
+      "version": "5.8.19"
     },
     {
       "slug": "grafana-splunk-monitoring-datasource",
-      "version": "1.7.10"
+      "version": "1.8.9"
     },
     {
       "slug": "grafana-timestream-datasource",
-      "version": "2.9.13"
+      "version": "2.13.0"
     },
     {
       "slug": "grafana-wavefront-datasource",
-      "version": "2.5.8"
+      "version": "2.5.17"
     },
     {
       "slug": "grafana-x-ray-datasource",
-      "version": "2.13.1"
+      "version": "2.17.0"
     },
     {
       "slug": "marcusolsson-gantt-panel",
@@ -139,7 +139,7 @@
     },
     {
       "slug": "netsage-sankey-panel",
-      "version": "1.1.3"
+      "version": "1.1.4"
     },
     {
       "slug": "operato-windrose-panel",
@@ -155,35 +155,67 @@
     },
     {
       "slug": "simpod-json-datasource",
-      "version": "0.6.6"
+      "version": "0.6.7"
     },
     {
       "slug": "volkovlabs-echarts-panel",
-      "version": "6.5.0"
+      "version": "7.2.4"
     },
     {
       "slug": "volkovlabs-form-panel",
-      "version": "5.0.0"
+      "version": "6.3.2"
     },
     {
       "slug": "volkovlabs-grapi-datasource",
-      "version": "3.4.0"
+      "version": "3.6.0"
     },
     {
       "slug": "volkovlabs-image-panel",
-      "version": "6.2.0"
+      "version": "7.3.0"
     },
     {
       "slug": "volkovlabs-rss-datasource",
-      "version": "4.3.0"
+      "version": "4.4.0"
     },
     {
       "slug": "volkovlabs-table-panel",
-      "version": "2.0.0"
+      "version": "3.6.3"
     },
     {
       "slug": "volkovlabs-variable-panel",
+      "version": "5.1.3"
+    },
+    {
+      "slug": "volkovlabs-echarts-panel",
+      "version": "7.2.4"
+    },
+    {
+      "slug": "volkovlabs-form-panel",
+      "version": "6.3.2"
+    },
+    {
+      "slug": "volkovlabs-links-panel",
+      "version": "2.6.0"
+    },
+    {
+      "slug": "volkovlabs-image-panel",
+      "version": "7.3.0"
+    },
+    {
+      "slug": "volkovlabs-rss-datasource",
+      "version": "4.4.0"
+    },
+    {
+      "slug": "volkovlabs-grapi-datasource",
       "version": "3.6.0"
+    },
+    {
+      "slug": "volkovlabs-table-panel",
+      "version": "3.6.3"
+    },
+    {
+      "slug": "volkovlabs-variable-panel",
+      "version": "5.1.3"
     }
   ]
 }

--- a/suraya/marimo/Dockerfile
+++ b/suraya/marimo/Dockerfile
@@ -1,7 +1,7 @@
 # Build definition for Marimo Suraya.
 
 # Define Python version.
-ARG PYTHON_VERSION="3.13"
+ARG PYTHON_VERSION="3.14"
 
 FROM python:${PYTHON_VERSION}-slim-bookworm
 


### PR DESCRIPTION
## About

Grafana 13 was released on 2026-04-21.

## References

- https://grafana.com/blog/grafana-13-release-all-the-latest-features/
- https://grafana.com/blog/grafanacon-2026-announcements/
